### PR TITLE
Add marketplace.json for Claude Code plugin discovery

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "name": "kolesar-barakah-cli",
+  "owner": {
+    "name": "BarakahCLI Contributors"
+  },
+  "metadata": {
+    "description": "Islamic mindfulness plugins for Claude Code"
+  },
+  "plugins": [
+    {
+      "name": "barakah-cli",
+      "source": "./",
+      "description": "The Islamic Productivity Plugin for Claude Code"
+    }
+  ]
+}


### PR DESCRIPTION
Asalaam, 

Adding `.claude-plugin/marketplace.json` so the plugin can be discovered via `/plugin marketplace add`.

Without this file, Claude Code errors out:

Error: Marketplace file not found at .claude-plugin/marketplace.json

JazakAllahu Khairan for the plugin — this PR just adds the missing marketplace manifest so it installs cleanly.